### PR TITLE
Allow specifying LDAP server

### DIFF
--- a/Certify/Commands/CAs.cs
+++ b/Certify/Commands/CAs.cs
@@ -15,6 +15,7 @@ namespace Certify.Commands
         private bool showAllPermissions;
         private string? caArg;
         private string? domain;
+        private string? ldapServer;
 
         public void Execute(Dictionary<string, string> arguments)
         {
@@ -43,10 +44,15 @@ namespace Certify.Commands
                 }
             }
 
+            if (arguments.ContainsKey("/ldapserver"))
+            {
+                ldapServer = arguments["/ldapserver"];
+            }
+
 
             _ldap = new LdapOperations(new LdapSearchOptions()
             {
-                Domain = domain
+                Domain = domain, LdapServer = ldapServer
             });
 
             Console.WriteLine($"[*] Using the search base '{_ldap.ConfigurationPath}'");

--- a/Certify/Commands/Find.cs
+++ b/Certify/Commands/Find.cs
@@ -66,6 +66,7 @@ namespace Certify.Commands
         private bool _outputJSON;
         private string? _certificateAuthority = null;
         private string? _domain = null;
+        private string? _ldapServer = null;
         private FindFilter _findFilter = FindFilter.None;
 
         public void Execute(Dictionary<string, string> arguments)
@@ -81,6 +82,11 @@ namespace Certify.Commands
                     Console.WriteLine("[!] /domain:X must be a FQDN");
                     return;
                 }
+            }
+
+            if (arguments.ContainsKey("/ldapserver"))
+            {
+                _ldapServer = arguments["/ldapserver"];
             }
 
             if (arguments.ContainsKey("/ca"))
@@ -128,7 +134,7 @@ namespace Certify.Commands
         {
             var ldap = new LdapOperations(new LdapSearchOptions()
             {
-                Domain = _domain
+                Domain = _domain, LdapServer = _ldapServer
             });
 
             if(!outputJSON)

--- a/Certify/Commands/PKIObjects.cs
+++ b/Certify/Commands/PKIObjects.cs
@@ -14,6 +14,7 @@ namespace Certify.Commands
         private LdapOperations _ldap = new LdapOperations();
         private bool hideAdmins;
         private string? domain;
+        private string? ldapServer;
 
         public void Execute(Dictionary<string, string> arguments)
         {
@@ -31,9 +32,14 @@ namespace Certify.Commands
                 }
             }
 
+            if (arguments.ContainsKey("/ldapserver"))
+            {
+                ldapServer = arguments["/ldapserver"];
+            }
+
             _ldap = new LdapOperations(new LdapSearchOptions()
             {
-                Domain = domain
+                Domain = domain, LdapServer = ldapServer
             });
 
             Console.WriteLine($"[*] Using the search base '{_ldap.ConfigurationPath}'");

--- a/Certify/Info.cs
+++ b/Certify/Info.cs
@@ -22,41 +22,41 @@ namespace Certify
             string usage = @"
   Find information about all registered CAs:
     
-    Certify.exe cas [/ca:SERVER\ca-name | /domain:domain.local | /path:CN=Configuration,DC=domain,DC=local] [/hideAdmins] [/showAllPermissions] [/skipWebServiceChecks] [/quiet]
+    Certify.exe cas [/ca:SERVER\ca-name | /domain:domain.local | /ldapserver:server.domain.local | /path:CN=Configuration,DC=domain,DC=local] [/hideAdmins] [/showAllPermissions] [/skipWebServiceChecks] [/quiet]
   
 
   Find all enabled certificate templates:
     
-    Certify.exe find [/ca:SERVER\ca-name | /domain:domain.local | /path:CN=Configuration,DC=domain,DC=local] [/quiet]
+    Certify.exe find [/ca:SERVER\ca-name | /domain:domain.local | /ldapserver:server.domain.local | /path:CN=Configuration,DC=domain,DC=local] [/quiet]
 
   Find vulnerable/abusable certificate templates using default low-privileged groups:
 
-    Certify.exe find /vulnerable [/ca:SERVER\ca-name | /domain:domain.local | /path:CN=Configuration,DC=domain,DC=local] [/quiet]
+    Certify.exe find /vulnerable [/ca:SERVER\ca-name | /domain:domain.local | /ldapserver:server.domain.local | /path:CN=Configuration,DC=domain,DC=local] [/quiet]
 
   Find vulnerable/abusable certificate templates using all groups the current user context is a part of:
 
-    Certify.exe find /vulnerable /currentuser [/ca:SERVER\ca-name | /domain:domain.local | /path:CN=Configuration,DC=domain,DC=local] [/quiet]
+    Certify.exe find /vulnerable /currentuser [/ca:SERVER\ca-name | /domain:domain.local | /ldapserver:server.domain.local | /path:CN=Configuration,DC=domain,DC=local] [/quiet]
 
   Find enabled certificate templates where ENROLLEE_SUPPLIES_SUBJECT is enabled:
 
-    Certify.exe find /enrolleeSuppliesSubject [/ca:SERVER\ca-name| /domain:domain.local | /path:CN=Configuration,DC=domain,DC=local] [/quiet]
+    Certify.exe find /enrolleeSuppliesSubject [/ca:SERVER\ca-name| /domain:domain.local | /ldapserver:server.domain.local | /path:CN=Configuration,DC=domain,DC=local] [/quiet]
 
   Find enabled certificate templates capable of client authentication:
 
-    Certify.exe find /clientauth [/ca:SERVER\ca-name | /domain:domain.local | /path:CN=Configuration,DC=domain,DC=local] [/quiet]
+    Certify.exe find /clientauth [/ca:SERVER\ca-name | /domain:domain.local | /ldapserver:server.domain.local | /path:CN=Configuration,DC=domain,DC=local] [/quiet]
 
   Find all enabled certificate templates, display all of their permissions, and don't display the banner message:
     
-    Certify.exe find /showAllPermissions /quiet [/ca:COMPUTER\CA_NAME | /domain:domain.local | /path:CN=Configuration,DC=domain,DC=local]
+    Certify.exe find /showAllPermissions /quiet [/ca:COMPUTER\CA_NAME | /domain:domain.local | /ldapserver:server.domain.local | /path:CN=Configuration,DC=domain,DC=local]
 
   Find all enabled certificate templates and output to a json file:
     
-    Certify.exe find /json /outfile:C:\Temp\out.json [/ca:COMPUTER\CA_NAME | /domain:domain.local | /path:CN=Configuration,DC=domain,DC=local]
+    Certify.exe find /json /outfile:C:\Temp\out.json [/ca:COMPUTER\CA_NAME | /domain:domain.local | /ldapserver:server.domain.local | /path:CN=Configuration,DC=domain,DC=local]
 
 
   Enumerate access control information for PKI objects:
 
-    Certify.exe pkiobjects [/domain:domain.local] [/showAdmins] [/quiet]
+    Certify.exe pkiobjects [/domain:domain.local | /ldapserver:server.domain.local] [/showAdmins] [/quiet]
 
 
   Request a new certificate using the current user context:

--- a/Certify/Lib/LdapOperations.cs
+++ b/Certify/Lib/LdapOperations.cs
@@ -14,6 +14,7 @@ namespace Certify.Lib
     {
         private readonly LdapSearchOptions _searchOptions;
         private string? _configurationPath = null;
+        private string? _ldapServer = null;
 
         public string ConfigurationPath
         {
@@ -28,6 +29,25 @@ namespace Certify.Lib
             }
 
             set => _configurationPath = value;
+        }
+
+        public string LdapServer
+        {
+            get
+            {
+                if (_searchOptions.LdapServer == null)
+                {
+                    _ldapServer = "";
+                }
+                else
+                {
+                    _ldapServer = $"{_searchOptions.LdapServer}/";
+                }
+
+                return _ldapServer;
+            }
+
+            set => _ldapServer = value;
         }
 
         public LdapOperations()
@@ -54,7 +74,7 @@ namespace Certify.Lib
 
             // Container location per MS-WCCE 2.2.2.11.2 Enrollment Services Container
             // - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/3ec073ec-9b91-4bee-964e-56f22a93a28c
-            var root = new DirectoryEntry($"LDAP://CN=Public Key Services,CN=Services,{ConfigurationPath}");
+            var root = new DirectoryEntry($"LDAP://{LdapServer}CN=Public Key Services,CN=Services,{ConfigurationPath}");
 
             var ds = new DirectorySearcher(root)
             {
@@ -126,7 +146,7 @@ namespace Certify.Lib
 
             // Container location per MS-WCCE 2.2.2.11.2 Enrollment Services Container
             // - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/3ec073ec-9b91-4bee-964e-56f22a93a28c
-            var root = new DirectoryEntry($"LDAP://CN=Enrollment Services,CN=Public Key Services,CN=Services,{ConfigurationPath}");
+            var root = new DirectoryEntry($"LDAP://{LdapServer}CN=Enrollment Services,CN=Public Key Services,CN=Services,{ConfigurationPath}");
             var ds = new DirectorySearcher(root);
 
             if (caName == null) ds.Filter = "(objectCategory=pKIEnrollmentService)";
@@ -176,7 +196,7 @@ namespace Certify.Lib
         {
             // Container location per MS-WCCE 2.2.2.11.3 NTAuthCertificates Object
             // - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/f1004c63-8508-43b5-9b0b-ee7880183745
-            var root = new DirectoryEntry($"LDAP://CN=NTAuthCertificates,CN=Public Key Services,CN=Services,{ConfigurationPath}");
+            var root = new DirectoryEntry($"LDAP://{LdapServer}CN=NTAuthCertificates,CN=Public Key Services,CN=Services,{ConfigurationPath}");
             var ds = new DirectorySearcher(root);
             ds.Filter = "(objectClass=certificationAuthority)";
 
@@ -209,7 +229,7 @@ namespace Certify.Lib
 
             // Container location per MS-WCCE 2.2.2.11.1 Certificates Templates Container
             // - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/9279abb2-3dfa-4631-845c-43c187ac4b44
-            var root = new DirectoryEntry($"LDAP://CN=Certificate Templates,CN=Public Key Services,CN=Services,{ConfigurationPath}");
+            var root = new DirectoryEntry($"LDAP://{LdapServer}CN=Certificate Templates,CN=Public Key Services,CN=Services,{ConfigurationPath}");
             var ds = new DirectorySearcher(root)
             {
                 SecurityMasks = SecurityMasks.Dacl | SecurityMasks.Owner,
@@ -272,7 +292,7 @@ namespace Certify.Lib
 
             // Container location per MS-WCCE 2.2.2.11.4 Certification Authorities Container
             // - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/6c446198-f670-4885-97a9-cbc50a2b96b4
-            var root = new DirectoryEntry($"LDAP://CN=Certification Authorities,CN=Public Key Services,CN=Services,{ConfigurationPath}");
+            var root = new DirectoryEntry($"LDAP://{LdapServer}CN=Certification Authorities,CN=Public Key Services,CN=Services,{ConfigurationPath}");
             var ds = new DirectorySearcher(root);
 
             ds.Filter = "(objectCategory=certificationAuthority)";

--- a/Certify/Lib/LdapSearchOptions.cs
+++ b/Certify/Lib/LdapSearchOptions.cs
@@ -5,10 +5,12 @@
         public LdapSearchOptions()
         {
             Domain = null;
+            LdapServer = null;
             //AuthenticationType = null;
             //Credential = null;
         }
         public string? Domain { get; set; }
+        public string? LdapServer { get; set; }
         //public AuthenticationTypes? AuthenticationType { get; set; }
         //public NetworkCredential? Credential { get; set; }
     }


### PR DESCRIPTION
Hi !

This commit adds the option `/ldapserver:` to commands `cas`, `find`, and `pkiobjects` allowing to specify the LDAP server to query.

I recently had an environment where, for some reason, the first IP returned when resolving the domain name was invalid. As such, Certify did not work as it did not manage to connect to the resolved IP. This switch lets the user specify the target LDAP server to query, in order to make the tool usable in this (probably rare) edge case.

Cheers !