### PR TITLE
Add mspki-certificate-application-policy output and fix comment

### DIFF
--- a/Certify/Commands/Find.cs
+++ b/Certify/Commands/Find.cs
@@ -12,7 +12,7 @@ using static Certify.Lib.DisplayUtil;
 
 namespace Certify.Commands
 {
-    class  ResultDTO
+    class ResultDTO
     {
         // used for JSON serialization
         public Dictionary<string, object>? Meta { get; }
@@ -111,7 +111,7 @@ namespace Certify.Commands
                 _findFilter = FindFilter.ClientAuth;
             }
 
-            if(arguments.ContainsKey("/json"))
+            if (arguments.ContainsKey("/json"))
             {
                 _outputJSON = true;
             }
@@ -131,7 +131,7 @@ namespace Certify.Commands
                 Domain = _domain
             });
 
-            if(!outputJSON)
+            if (!outputJSON)
                 Console.WriteLine($"[*] Using the search base '{ldap.ConfigurationPath}'");
 
             if (!string.IsNullOrEmpty(_certificateAuthority))
@@ -224,7 +224,7 @@ namespace Certify.Commands
                 List<CertificateTemplateDTO> templateDTOs = new List<CertificateTemplateDTO>();
 
                 // TODO: how to implement this in LINQ?
-                foreach(var template in templates)
+                foreach (var template in templates)
                 {
                     if (publishedTemplateNames.Contains(template.Name))
                     {
@@ -247,21 +247,21 @@ namespace Certify.Commands
 
         private void PrintCertTemplate(EnterpriseCertificateAuthority ca, CertificateTemplate template)
         {
-            Console.WriteLine($"    CA Name                         : {ca.FullName}");
-            Console.WriteLine($"    Template Name                   : {template.Name}");
-            Console.WriteLine($"    Schema Version                  : {template.SchemaVersion}");
-            Console.WriteLine($"    Validity Period                 : {template.ValidityPeriod}");
-            Console.WriteLine($"    Renewal Period                  : {template.RenewalPeriod}");
-            Console.WriteLine($"    msPKI-Certificates-Name-Flag    : {template.CertificateNameFlag}");
-            Console.WriteLine($"    mspki-enrollment-flag           : {template.EnrollmentFlag}");
-            Console.WriteLine($"    Authorized Signatures Required  : {template.AuthorizedSignatures}");
+            Console.WriteLine($"    CA Name                               : {ca.FullName}");
+            Console.WriteLine($"    Template Name                         : {template.Name}");
+            Console.WriteLine($"    Schema Version                        : {template.SchemaVersion}");
+            Console.WriteLine($"    Validity Period                       : {template.ValidityPeriod}");
+            Console.WriteLine($"    Renewal Period                        : {template.RenewalPeriod}");
+            Console.WriteLine($"    msPKI-Certificates-Name-Flag          : {template.CertificateNameFlag}");
+            Console.WriteLine($"    mspki-enrollment-flag                 : {template.EnrollmentFlag}");
+            Console.WriteLine($"    Authorized Signatures Required        : {template.AuthorizedSignatures}");
             if (template.ApplicationPolicies != null && template.ApplicationPolicies.Any())
             {
                 var applicationPolicyFriendNames = template.ApplicationPolicies
                     .Select(o => ((new Oid(o)).FriendlyName))
                     .OrderBy(s => s)
                     .ToArray();
-                Console.WriteLine($"    Application Policies            : {string.Join(", ", applicationPolicyFriendNames)}");
+                Console.WriteLine($"    Application Policies                  : {string.Join(", ", applicationPolicyFriendNames)}");
             }
             if (template.IssuancePolicies != null && template.IssuancePolicies.Any())
             {
@@ -269,15 +269,22 @@ namespace Certify.Commands
                     .Select(o => ((new Oid(o)).FriendlyName))
                     .OrderBy(s => s)
                     .ToArray();
-                Console.WriteLine($"    Issuance Policies               : {string.Join(", ", issuancePolicyFriendNames)}");
+                Console.WriteLine($"    Issuance Policies                     : {string.Join(", ", issuancePolicyFriendNames)}");
             }
 
             var oidFriendlyNames = template.ExtendedKeyUsage == null
-                ? new []{"<null>"}
+                ? new[] { "<null>" }
                 : template.ExtendedKeyUsage.Select(o => ((new Oid(o)).FriendlyName))
                 .OrderBy(s => s)
                 .ToArray();
-            Console.WriteLine($"    pkiextendedkeyusage             : {string.Join(", ", oidFriendlyNames)}");
+            Console.WriteLine($"    pkiextendedkeyusage                   : {string.Join(", ", oidFriendlyNames)}");
+
+            var certificateApplicationPolicyFriendlyNames = template.CertificateApplicationPolicies == null
+                ? new[] { "<null>" }
+                : template.CertificateApplicationPolicies.Select(o => ((new Oid(o)).FriendlyName))
+                .OrderBy(s => s)
+                .ToArray();
+            Console.WriteLine($"    mspki-certificate-application-policy  : {string.Join(", ", certificateApplicationPolicyFriendlyNames)}");
 
             Console.WriteLine("    Permissions");
             if (_showAllPermissions)
@@ -314,7 +321,7 @@ namespace Certify.Commands
                 if ((rule.ActiveDirectoryRights & ActiveDirectoryRights.ExtendedRight) == ActiveDirectoryRights.ExtendedRight)
                 {
                     // 0e10c968-78fb-11d2-90d4-00c04f79dc55  ->  Certificates-Enrollment right
-                    // 0e10c968-78fb-11d2-90d4-00c04f79dc55  ->  Certificates-AutoEnrollment right
+                    // a05b8cc2-17bc-4802-a710-e7c15ab866a2  ->  Certificates-AutoEnrollment right
                     // 00000000-0000-0000-0000-000000000000  ->  all extended rights
                     switch ($"{rule.ObjectType}")
                     {
@@ -559,7 +566,8 @@ namespace Certify.Commands
             {
                 Console.WriteLine("\n[+] No Vulnerable Certificates Templates found!\n");
             }
-            else {
+            else
+            {
                 Console.WriteLine("\n[!] Vulnerable Certificates Templates :\n");
             }
 
@@ -674,7 +682,7 @@ namespace Certify.Commands
 
             }
 
-            if(vulnerableACL)
+            if (vulnerableACL)
             {
                 return true;
             }
@@ -695,7 +703,7 @@ namespace Certify.Commands
                 (template.ExtendedKeyUsage.Contains(CommonOids.SmartcardLogon) ||
                 template.ExtendedKeyUsage.Contains(CommonOids.ClientAuthentication) ||
                 template.ExtendedKeyUsage.Contains(CommonOids.PKINITClientAuthentication));
-            
+
             if (lowPrivilegedUsersCanEnroll && enrolleeSuppliesSubject && hasAuthenticationEku) return true;
 
 

--- a/Certify/Domain/CertificateTemplate.cs
+++ b/Certify/Domain/CertificateTemplate.cs
@@ -115,6 +115,7 @@ namespace Certify.Domain
         public int? AuthorizedSignatures { get; }
         public IEnumerable<string>? ApplicationPolicies { get; }
         public IEnumerable<string>? IssuancePolicies { get; }
+        public IEnumerable<string>? CertificateApplicationPolicies { get; }
 
         // vulnerability-related settings
         public bool? RequiresManagerApproval { get; }
@@ -138,6 +139,7 @@ namespace Certify.Domain
             ExtendedKeyUsage = template?.ExtendedKeyUsage;
             AuthorizedSignatures = template?.AuthorizedSignatures;
             IssuancePolicies = template?.IssuancePolicies;
+            CertificateApplicationPolicies = template?.CertificateApplicationPolicies;
 
             var requiresManagerApproval = template.EnrollmentFlag != null && ((msPKIEnrollmentFlag)template.EnrollmentFlag).HasFlag(msPKIEnrollmentFlag.PEND_ALL_REQUESTS);
             var enrolleeSuppliesSubject = template.CertificateNameFlag != null && ((msPKICertificateNameFlag)template.CertificateNameFlag).HasFlag(msPKICertificateNameFlag.ENROLLEE_SUPPLIES_SUBJECT);
@@ -158,7 +160,7 @@ namespace Certify.Domain
 
     class CertificateTemplate : ADObject
     {
-        public CertificateTemplate(string name, string domainName, Guid? guid, int? schemaVersion, string displayName, string validityPeriod, string renewalPeriod, Oid oid, msPKICertificateNameFlag? certificateNameFlag, msPKIEnrollmentFlag? enrollmentFlag, IEnumerable<string> extendedKeyUsage, int? authorizedSignatures, IEnumerable<string> applicationPolicies, IEnumerable<string> issuancePolicies, ActiveDirectorySecurity securityDescriptor)
+        public CertificateTemplate(string name, string domainName, Guid? guid, int? schemaVersion, string displayName, string validityPeriod, string renewalPeriod, Oid oid, msPKICertificateNameFlag? certificateNameFlag, msPKIEnrollmentFlag? enrollmentFlag, IEnumerable<string> extendedKeyUsage, int? authorizedSignatures, IEnumerable<string> applicationPolicies, IEnumerable<string> issuancePolicies, ActiveDirectorySecurity securityDescriptor, IEnumerable<string> certificateApplicationPolicies)
             : base(securityDescriptor)
         {
             Name = name;
@@ -175,6 +177,7 @@ namespace Certify.Domain
             AuthorizedSignatures = authorizedSignatures;
             ApplicationPolicies = applicationPolicies;
             IssuancePolicies = issuancePolicies;
+            CertificateApplicationPolicies = certificateApplicationPolicies;
         }
         public string? Name { get; }
         public string? DomainName { get; }
@@ -190,5 +193,6 @@ namespace Certify.Domain
         public int? AuthorizedSignatures { get; }
         public IEnumerable<string>? ApplicationPolicies { get; }
         public IEnumerable<string>? IssuancePolicies { get; }
+        public IEnumerable<string>? CertificateApplicationPolicies { get; }
     }
 }

--- a/Certify/Lib/LdapOperations.cs
+++ b/Certify/Lib/LdapOperations.cs
@@ -171,7 +171,7 @@ namespace Certify.Lib
             return cas;
         }
 
-       
+
         public CertificateAuthority GetNtAuthCertificates()
         {
             // Container location per MS-WCCE 2.2.2.11.3 NTAuthCertificates Object
@@ -243,6 +243,8 @@ namespace Certify.Lib
 
                 var securityDescriptor = ParseSecurityDescriptor(sr);
 
+                var certificateApplicationPolicies = ParseCertificateApplicationPolicies(sr);
+
                 templates.Add(new CertificateTemplate(
                     name,
                     domainName,
@@ -258,7 +260,8 @@ namespace Certify.Lib
                     authorizedSignatures,
                     applicationPolicies,
                     issuancePolicies,
-                    securityDescriptor
+                    securityDescriptor,
+                    certificateApplicationPolicies
                 ));
             }
 
@@ -514,6 +517,14 @@ namespace Certify.Lib
             return from object oid in sr.Properties["mspki-ra-policies"] select oid.ToString();
         }
 
+        private static IEnumerable<string>? ParseCertificateApplicationPolicies(SearchResult sr)
+        {
+            if (!sr.Properties.Contains("mspki-certificate-application-policy"))
+                return null;
+
+            return from object oid in sr.Properties["mspki-certificate-application-policy"] select oid.ToString();
+        }
+
         private T ParseUIntToEnum<T>(string value)
         {
             var uintVal = Convert.ToUInt32(value);
@@ -601,6 +612,6 @@ namespace Certify.Lib
             {
                 return "ERROR";
             }
-        }        
+        }
     }
 }


### PR DESCRIPTION
Hi.

I investigated ESC4 senario in ["Certified Pre-Owned: Abusing Active Directory Certificate Services"](https://posts.specterops.io/certified-pre-owned-d95910965cd2).
Through investigation, I noticed that `mspki-certificate-application-policy` attribute is important part of ACL abusing, but Certify does not output `mspki-certificate-application-policy` attribute in its result.
So I added code for displaying `mspki-certificate-application-policy` attribute.

My investigation is available at the following url:

https://github.com/daem0nc0re/Abusing_Weak_ACL_on_Certificate_Templates

Additionally, I noticed that the GUID for `Certificate-AutoEnrollment` in comment is wrong, and fixed it.