### PR TITLE
Extended request command

### DIFF
--- a/Certify/Certify.csproj
+++ b/Certify/Certify.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Domain\EnterpriseCertificateAuthority.cs" />
     <Compile Include="Domain\PKIObject.cs" />
     <Compile Include="Info.cs" />
+    <Compile Include="Lib\CertConverter.cs" />
     <Compile Include="Lib\HttpUtil.cs" />
     <Compile Include="Lib\LdapSearchOptions.cs" />
     <Compile Include="Version.cs" />

--- a/Certify/Commands/Request.cs
+++ b/Certify/Commands/Request.cs
@@ -17,6 +17,9 @@ namespace Certify.Commands
             var template = "User";
             var machineContext = false;
             var install = false;
+            var pfx = false;
+            var password = "Password123!";
+            var nowrap = false;
 
             if (arguments.ContainsKey("/ca"))
             {
@@ -53,6 +56,21 @@ namespace Certify.Commands
                 install = true;
             }
 
+            if (arguments.ContainsKey("/pfx"))
+            {
+                pfx = true;
+            }
+
+            if (arguments.ContainsKey("/password"))
+            {
+                password = arguments["/password"];
+            }
+
+            if (arguments.ContainsKey("/nowrap"))
+            {
+                nowrap = true;
+            }
+
             if (arguments.ContainsKey("/computer") || arguments.ContainsKey("/machine"))
             {
                 if (template == "User")
@@ -80,11 +98,11 @@ namespace Certify.Commands
                     return;
                 }
 
-                Cert.RequestCertOnBehalf(CA, template, arguments["/onbehalfof"], arguments["/enrollcert"], enrollCertPassword, machineContext);
+                Cert.RequestCertOnBehalf(CA, template, arguments["/onbehalfof"], arguments["/enrollcert"], enrollCertPassword, machineContext, pfx, password, nowrap);
             }
             else
             {
-                Cert.RequestCert(CA, machineContext, template, subject, altName, install);
+                Cert.RequestCert(CA, machineContext, template, subject, altName, install, pfx, password, nowrap);
             }
         }
     }

--- a/Certify/Lib/CertConverter.cs
+++ b/Certify/Lib/CertConverter.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Certify.Lib
+{
+    class CertConverter
+    {
+        internal class RSAParameterTraits
+        {
+            /*
+             * Reference : 
+             *     https://www.codeproject.com/Articles/162194/Certificates-to-DB-and-Back
+             */
+            public RSAParameterTraits(int modulusLengthInBits)
+            {
+                int assumedLength = -1;
+                double logbase = Math.Log(modulusLengthInBits, 2);
+                if (logbase == (int)logbase)
+                {
+                    assumedLength = modulusLengthInBits;
+                }
+                else
+                {
+                    assumedLength = (int)(logbase + 1.0);
+                    assumedLength = (int)(Math.Pow(2, assumedLength));
+                    System.Diagnostics.Debug.Assert(false);
+                }
+
+                switch (assumedLength)
+                {
+                    case 1024:
+                        this.size_Mod = 0x80;
+                        this.size_Exp = -1;
+                        this.size_D = 0x80;
+                        this.size_P = 0x40;
+                        this.size_Q = 0x40;
+                        this.size_DP = 0x40;
+                        this.size_DQ = 0x40;
+                        this.size_InvQ = 0x40;
+                        break;
+                    case 2048:
+                        this.size_Mod = 0x100;
+                        this.size_Exp = -1;
+                        this.size_D = 0x100;
+                        this.size_P = 0x80;
+                        this.size_Q = 0x80;
+                        this.size_DP = 0x80;
+                        this.size_DQ = 0x80;
+                        this.size_InvQ = 0x80;
+                        break;
+                    case 4096:
+                        this.size_Mod = 0x200;
+                        this.size_Exp = -1;
+                        this.size_D = 0x200;
+                        this.size_P = 0x100;
+                        this.size_Q = 0x100;
+                        this.size_DP = 0x100;
+                        this.size_DQ = 0x100;
+                        this.size_InvQ = 0x100;
+                        break;
+                    default:
+                        System.Diagnostics.Debug.Assert(false);
+                        break;
+                }
+            }
+
+            public int size_Mod = -1;
+            public int size_Exp = -1;
+            public int size_D = -1;
+            public int size_P = -1;
+            public int size_Q = -1;
+            public int size_DP = -1;
+            public int size_DQ = -1;
+            public int size_InvQ = -1;
+        }
+
+        private static byte[] AlignBytes(byte[] inputBytes, int alignSize)
+        {
+            int inputBytesSize = inputBytes.Length;
+
+            if ((alignSize != -1) && (inputBytesSize < alignSize))
+            {
+                byte[] buf = new byte[alignSize];
+
+                for (int i = 0; i < inputBytesSize; ++i)
+                {
+                    buf[i + (alignSize - inputBytesSize)] = inputBytes[i];
+                }
+
+                return buf;
+            }
+            else
+            {
+                return inputBytes;
+            }
+        }
+
+        private static RSACryptoServiceProvider DecodePrivateKey(byte[] privKey)
+        {
+            MemoryStream memoryStream = new MemoryStream(privKey);
+            BinaryReader binaryReader = new BinaryReader(memoryStream);
+
+            try
+            {
+                int storage = (int)binaryReader.ReadUInt16();
+
+                if (storage == 0x8130)
+                {
+                    binaryReader.ReadByte();
+                }
+                else if (storage == 0x8230)
+                {
+                    binaryReader.ReadUInt16();
+                }
+                else
+                {
+                    throw new InvalidDataException("invalid data format");
+                }
+
+                storage = (int)binaryReader.ReadUInt16();
+
+                if (storage != 0x0102)
+                {
+                    throw new InvalidDataException("invalid data format");
+                }
+
+                storage = (int)binaryReader.ReadByte();
+
+                if (storage != 0)
+                {
+                    throw new InvalidDataException("invalid data format");
+                }
+
+                CspParameters cspParams = new CspParameters();
+                cspParams.Flags = CspProviderFlags.NoFlags;
+                cspParams.KeyContainerName = Guid.NewGuid().ToString().ToUpperInvariant();
+                cspParams.ProviderType = 0x18;
+
+                RSACryptoServiceProvider rsa = new RSACryptoServiceProvider(cspParams);
+                RSAParameters rsaParams = new RSAParameters();
+                rsaParams.Modulus = binaryReader.ReadBytes(DecodeSize(binaryReader));
+
+                RSAParameterTraits traits = new RSAParameterTraits(rsaParams.Modulus.Length * 8);
+
+                rsaParams.Modulus = AlignBytes(rsaParams.Modulus, traits.size_Mod);
+                rsaParams.Exponent = AlignBytes(binaryReader.ReadBytes(DecodeSize(binaryReader)), traits.size_Exp);
+                rsaParams.D = AlignBytes(binaryReader.ReadBytes(DecodeSize(binaryReader)), traits.size_D);
+                rsaParams.P = AlignBytes(binaryReader.ReadBytes(DecodeSize(binaryReader)), traits.size_P);
+                rsaParams.Q = AlignBytes(binaryReader.ReadBytes(DecodeSize(binaryReader)), traits.size_Q);
+                rsaParams.DP = AlignBytes(binaryReader.ReadBytes(DecodeSize(binaryReader)), traits.size_DP);
+                rsaParams.DQ = AlignBytes(binaryReader.ReadBytes(DecodeSize(binaryReader)), traits.size_DQ);
+                rsaParams.InverseQ = AlignBytes(binaryReader.ReadBytes(DecodeSize(binaryReader)), traits.size_InvQ);
+
+                rsa.ImportParameters(rsaParams);
+
+                return rsa;
+            }
+            catch
+            {
+                return null;
+            }
+            finally
+            {
+                binaryReader.Close();
+            }
+        }
+
+        private static int DecodeSize(BinaryReader binaryReader)
+        {
+            int count;
+            int storage = (int)binaryReader.ReadByte();
+
+            if (storage != 2)
+            {
+                throw new InvalidDataException("invalid data format");
+            }
+
+            storage = (int)binaryReader.ReadByte();
+
+            if (storage == 0x81)
+            {
+                count = (int)binaryReader.ReadByte();
+            }
+            else if (storage == 0x82)
+            {
+                count = ((int)binaryReader.ReadByte()) << 8;
+                count += (int)binaryReader.ReadByte();
+            }
+            else
+            {
+                count = storage;
+            }
+
+            while (binaryReader.ReadByte() == 0)
+            {
+                count--;
+            }
+
+            binaryReader.BaseStream.Seek(-1, System.IO.SeekOrigin.Current);
+
+            return count;
+        }
+
+        private static byte[] GetPrivateKeyFromPemString(string pem)
+        {
+            MatchCollection matches;
+            string base64Content;
+            Regex regexPrivateKey = new Regex(
+                @"-+BEGIN RSA PRIVATE KEY-+[a-zA-Z0-9\+=/\r\n]+-+END RSA PRIVATE KEY-+",
+                RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+            matches = regexPrivateKey.Matches(pem);
+
+            if (matches.Count == 0)
+            {
+                throw new InvalidOperationException("Failed to get private key");
+            }
+
+            base64Content = Regex.Replace(
+                matches[0].ToString(),
+                @"(-+[A-Z\s]+-+|\s+)",
+                string.Empty);
+
+            return Convert.FromBase64String(base64Content);
+        }
+
+        private static byte[] GetPublicKeyFromPemString(string pem)
+        {
+            MatchCollection matches;
+            string base64Content;
+            Regex regexCertificate = new Regex(
+                @"-+BEGIN CERTIFICATE-+[a-zA-Z0-9\+/=\r\n]+-+END CERTIFICATE-+",
+                RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+            matches = regexCertificate.Matches(pem);
+
+            if (matches.Count == 0)
+            {
+                throw new InvalidOperationException("Failed to get certificate");
+            }
+
+            base64Content = Regex.Replace(
+                matches[0].ToString(),
+                @"(-+[A-Z\s]+-+|\s+)",
+                string.Empty);
+
+            return Convert.FromBase64String(base64Content);
+        }
+
+        public static string GetPfxFromPemString(string privateKeyPemString, string certPemString, string password, bool nowrap)
+        {
+            RSACryptoServiceProvider privKey = DecodePrivateKey(GetPrivateKeyFromPemString(privateKeyPemString));
+            X509Certificate2 cert = new X509Certificate2(GetPublicKeyFromPemString(certPemString));
+            cert.PrivateKey = privKey;
+
+            var encodedPfx = Convert.ToBase64String(cert.Export(X509ContentType.Pfx, password));
+            var result = new StringBuilder();
+
+            if (nowrap)
+            {
+                result.Append(encodedPfx);
+            }
+            else
+            {
+                for (var idx = 0; idx < encodedPfx.Length; idx++)
+                {
+                    result.Append(encodedPfx[idx]);
+                    if ((idx + 1) % 64 == 0)
+                    {
+                        result.Append("\r\n");
+                    }
+                }
+            }
+
+            return result.ToString();
+        }
+
+        public static bool IsBase64String(string s)
+        {
+            s = s.Trim();
+            return (s.Length % 4 == 0) && Regex.IsMatch(s, @"^[a-zA-Z0-9\+/]*={0,3}$", RegexOptions.None);
+        }
+    }
+}


### PR DESCRIPTION
Hi.

To prevent the trouble of converting pem output with `openssl`, I added the functionality to output pfx in Base64 format to the `request` command.
The added options are following:

+ `/pfx` : Flag for output certificate Base64 encoded pfx. Default value is `false`.

+ `/password` : Password for pfx file. Default value is `Password123!`.

+ `/nowrap` : Flag whether Base64 encoded pfx output should be wrapped or not. Default value is `false`.

I also extended `/enrollcert` option to accept Base64 pfx string like `Rubeus`.
As far as I tested, my changes work well for ESC1 and ESC3 senarios in my environment.