### PR TITLE
Small patch for potential null bug

### DIFF
--- a/Certify/Commands/Find.cs
+++ b/Certify/Commands/Find.cs
@@ -756,9 +756,10 @@ namespace Certify.Commands
 
             // Check 7) Does a certificate contain the  DISABLE_EMBED_SID_OID flag + DNS and DNS SAN flags
 
-            if((((msPKICertificateNameFlag)template.CertificateNameFlag).HasFlag(msPKICertificateNameFlag.SUBJECT_ALT_REQUIRE_DNS)
-                || ((msPKICertificateNameFlag)template.CertificateNameFlag).HasFlag(msPKICertificateNameFlag.SUBJECT_REQUIRE_DNS_AS_CN))
-                && ((msPKIEnrollmentFlag)template.EnrollmentFlag).HasFlag(msPKIEnrollmentFlag.NO_SECURITY_EXTENSION)) {
+            if (template.CertificateNameFlag != null && template.EnrollmentFlag != null && (((msPKICertificateNameFlag)template.CertificateNameFlag).HasFlag(msPKICertificateNameFlag.SUBJECT_ALT_REQUIRE_DNS)
+                    || ((msPKICertificateNameFlag)template.CertificateNameFlag).HasFlag(msPKICertificateNameFlag.SUBJECT_REQUIRE_DNS_AS_CN))
+                && ((msPKIEnrollmentFlag)template.EnrollmentFlag).HasFlag(msPKIEnrollmentFlag.NO_SECURITY_EXTENSION))
+            {
                 return true;
             }
 


### PR DESCRIPTION
The latest commit (on Visual Studio 2019) introduces a bug for the 7th check, specifically CS8629. A quick check to make sure it isn't null fixes it. Figured I'd send this over in case it helps.
![Null Bug](https://user-images.githubusercontent.com/1674822/169596922-f366c60b-8e2c-4b43-ad4e-1a1863c0549d.png)

