### PR TITLE
Windows native certutil.exe command

### DIFF
--- a/Certify/Lib/Cert.cs
+++ b/Certify/Lib/Cert.cs
@@ -353,6 +353,7 @@ namespace Certify
 
             Console.WriteLine(
                     "\r\n[*] Convert with: openssl pkcs12 -in cert.pem -keyex -CSP \"Microsoft Enhanced Cryptographic Provider v1.0\" -export -out cert.pfx\r\n");
+                    "\r\n[*] or (with the keyfile named cert.key): certutil.exe -MergePFX cert.pem cert.pfx");
         }
 
 
@@ -401,6 +402,7 @@ namespace Certify
                 Console.WriteLine(certPemString);
                 Console.WriteLine(
                     "\r\n[*] Convert with: openssl pkcs12 -in cert.pem -keyex -CSP \"Microsoft Enhanced Cryptographic Provider v1.0\" -export -out cert.pfx\r\n");
+                    "\r\n[*] or (with the keyfile named cert.key): certutil.exe -MergePFX cert.pem cert.pfx");
             }
             catch (Exception e)
             {

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Certificates can be transformed to .pfx's usable with Certify with:
 
     openssl pkcs12 -in cert.pem -keyex -CSP "Microsoft Enhanced Cryptographic Provider v1.0" -export -out cert.pfx
 
-The same can be done usig the Windows native tool `certutil.exe`:
+The same can be done usig the Windows native tool `certutil.exe` (with the keyfile named `cert.key`):
 
     certutil.exe -MergePFX cert.pem cert.pfx
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Certificates can be transformed to .pfx's usable with Certify with:
 
     openssl pkcs12 -in cert.pem -keyex -CSP "Microsoft Enhanced Cryptographic Provider v1.0" -export -out cert.pfx
 
+The same can be done usig the Windows native tool `certutil.exe`:
+
+    certutil.exe -MergePFX cert.pem cert.pfx
+
 Certificates can be used with Rubeus to request a TGT with:
 
     Rubeus.exe asktgt /user:X /certificate:C:\Temp\cert.pfx /password:<CERT_PASSWORD>


### PR DESCRIPTION
This adds the Windows native `certutil.exe` command as an alternative to the `openssl` command.