### PR TITLE
For ESC 3 the 2nd requirement is not evaluated

### DIFF
--- a/Certify/Commands/Find.cs
+++ b/Certify/Commands/Find.cs
@@ -749,7 +749,8 @@ namespace Certify.Commands
                 template.ExtendedKeyUsage == null
                 || !template.ExtendedKeyUsage.Any() // No EKUs == Any Purpose
                 || template.ExtendedKeyUsage.Contains(CommonOids.AnyPurpose)
-                || template.ExtendedKeyUsage.Contains(CommonOids.CertificateRequestAgent);
+                || template.ExtendedKeyUsage.Contains(CommonOids.CertificateRequestAgent)
+                || template.ApplicationPolicies.Contains(CommonOids.CertificateRequestAgentPolicy);
 
             if (lowPrivilegedUsersCanEnroll && hasDangerousEku) return true;
 

--- a/Certify/Domain/CommonOids.cs
+++ b/Certify/Domain/CommonOids.cs
@@ -7,5 +7,6 @@
         public static string PKINITClientAuthentication = "1.3.6.1.5.2.3.4";
         public static string SmartcardLogon = "1.3.6.1.4.1.311.20.2.2";
         public static string CertificateRequestAgent = "1.3.6.1.4.1.311.20.2.1";
+        public static string CertificateRequestAgentPolicy = "1.3.6.1.4.1.311.20.2.1";
     };
 }


### PR DESCRIPTION
When enumerating for ESC 3, the values to meet the 1st group of requirements is taken into consideration and according templates are flagged as vulnerable.
However the 2nd set, where the msPKI-RA-Application-Policies property needs to meet the OID=1.3.6.1.4.1.311.20.2.1=Certificate Request Agent is never evaluated.

I updated to OIDs and the find stuff accordingly, to take this into account, and also print out the templates meeting the 2nd group of criteria.