### PR TITLE
Fix for issue #25

### DIFF
--- a/Certify/Commands/Find.cs
+++ b/Certify/Commands/Find.cs
@@ -736,7 +736,7 @@ namespace Certify.Commands
                 || !template.ExtendedKeyUsage.Any() // No EKUs == Any Purpose
                 || template.ExtendedKeyUsage.Contains(CommonOids.AnyPurpose)
                 || template.ExtendedKeyUsage.Contains(CommonOids.CertificateRequestAgent)
-                || template.ApplicationPolicies.Contains(CommonOids.CertificateRequestAgentPolicy);
+                || (template.ApplicationPolicies != null && template.ApplicationPolicies.Contains(CommonOids.CertificateRequestAgentPolicy));
 
             if (lowPrivilegedUsersCanEnroll && hasDangerousEku) return true;
 


### PR DESCRIPTION
As identified in #25, when a template has no application policies the `Certify.Commands.Find.IsCertificateTemplateVulnerable` function hits a null reference when accessing `template.applicationPolicies` via the `Contains()` method.  This is used to check if a template is vulnerable because of an unsafe application policy.

To fix this, added a nullity check on `template.applicationPolicies`.  If it is null then we consider this check as passing.