### PR TITLE
Fix to show Web Enrollment Endpoint when run from non domain joined machine

### DIFF
--- a/Certify/Lib/HttpUtil.cs
+++ b/Certify/Lib/HttpUtil.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 
 namespace Certify.Lib
@@ -20,12 +20,21 @@ namespace Certify.Lib
             try
             {
                 using var response = (HttpWebResponse)request.GetResponse();
-                return response.StatusCode == HttpStatusCode.OK;
+                return response.StatusCode == HttpStatusCode.OK ||
+                       response.StatusCode == HttpStatusCode.Unauthorized ||
+                       response.StatusCode == HttpStatusCode.Forbidden;
             }
-            catch (WebException)
+            catch (WebException ex)
             {
+                // Check if the exception is due to Unauthorized (401) or Forbidden (403)
+                if (ex.Response is HttpWebResponse errorResponse)
+                {
+                    return errorResponse.StatusCode == HttpStatusCode.Unauthorized ||
+                           errorResponse.StatusCode == HttpStatusCode.Forbidden;
+                }
             }
 
+            // If there's an exception or the status code is not one of the expected ones, return false
             return false;
         }
     }


### PR DESCRIPTION
Due to the nature of the HttpUtil.cs script handling authentication via CredentialCache.DefaultNetworkCredentials), the tool would never reveal the Web Enrollment Endpoints when run from a non domain joined machine with
``runas /netonly /user:domain\testuser powershell``

The credentials are not in the cache and the tool only honors 200 OK to be true.
But there is also the endpoint available if we get a 403 or 401, we are just not authenticated.

I debugged this a little and wrote the results to the command line:
![image](https://github.com/GhostPack/Certify/assets/58529760/45b6d7b9-cc00-4488-8d87-3155a39b31c2)

After the changes it looks good:
![image](https://github.com/GhostPack/Certify/assets/58529760/95b314b3-4c57-4675-8165-b37d53244c77)

