### PR TITLE
Updated to add arg to specify x509 keysize.  

### DIFF
--- a/Certify/Commands/Request.cs
+++ b/Certify/Commands/Request.cs
@@ -18,6 +18,7 @@ namespace Certify.Commands
             var template = "User";
             var machineContext = false;
             var install = false;
+            var keySize = 2048;
 
             if (arguments.ContainsKey("/ca"))
             {
@@ -33,7 +34,22 @@ namespace Certify.Commands
                 Console.WriteLine("[X] A /ca:CA is required! (format SERVER\\CA-NAME)");
                 return;
             }
+            if (arguments.ContainsKey("/keysize"))
+            {
 
+                if (arguments["/keysize"].Equals("512") || arguments["/keysize"].Equals("1024") ||
+                    arguments["/keysize"].Equals("2048") || arguments["/keysize"].Equals("4096") )
+                {
+                    keySize = Int32.Parse(arguments["/keysize"]);
+                }
+                else
+                {
+                    Console.WriteLine("[X] /keysize must be either 512, 1024, 2048 (default) or 4096");
+                    return;
+                    
+                }
+                
+            }
             if (arguments.ContainsKey("/template"))
             {
                 template = arguments["/template"];
@@ -90,11 +106,11 @@ namespace Certify.Commands
                     return;
                 }
 
-                Cert.RequestCertOnBehalf(CA, template, arguments["/onbehalfof"], arguments["/enrollcert"], enrollCertPassword, machineContext);
+                Cert.RequestCertOnBehalf(CA, template, arguments["/onbehalfof"], arguments["/enrollcert"], enrollCertPassword, machineContext,keySize);
             }
             else
             {
-                Cert.RequestCert(CA, machineContext, template, subject, altName, sidExtension, install);
+                Cert.RequestCert(CA, machineContext, template, subject, altName, sidExtension, install,keySize);
             }
         }
     }

--- a/Certify/Info.cs
+++ b/Certify/Info.cs
@@ -67,6 +67,10 @@ namespace Certify
 
     Certify.exe request /ca:SERVER\ca-name /machine [/subject:X] [/template:Y] [/install]
 
+  Request a new certificate using the current machine context, specifying x509 key length:
+
+     Certify.exe request /ca:SERVER\ca-name /machine /keysize 4096 [/subject:X] [/template:Y] [/install]
+
   Request a new certificate using the current user context but for an alternate name (if supported):
 
     Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Certify is a C# tool to enumerate and abuse misconfigurations in Active Director
 
         Certify.exe request /ca:SERVER\ca-name /machine [/subject:X] [/template:Y] [/install]
 
+      Request a new certificate using the current machine context, specifying x509 key length:
+
+        Certify.exe request /ca:SERVER\ca-name /machine /keysize 4096 [/subject:X] [/template:Y] [/install]
+
       Request a new certificate using the current user context but for an alternate name (if supported):
 
         Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER


### PR DESCRIPTION
Solves Error 0x80094811 - Public key does not meet the minimum key size required by the specified certificate template