### PR TITLE
Added line to README/Usage defining ldapserver and subject arguments

### DIFF
--- a/Certify/Info.cs
+++ b/Certify/Info.cs
@@ -71,7 +71,7 @@ namespace Certify
 
     Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER
 
-  Request a new certificate using the current user context but for an alternate name (if supported), specifying a ldapserver your own subjectname:
+  Request a new certificate using the current user context but for an alternate name (if supported), specifying a ldapserver your own subject name:
 
     Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER /ldapserver:IP-Address /subject:DN-Format
 

--- a/Certify/Info.cs
+++ b/Certify/Info.cs
@@ -71,6 +71,10 @@ namespace Certify
 
     Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER
 
+  Request a new certificate using the current user context but for an alternate name (if supported), specifying a ldapserver your own subjectname:
+
+    Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER /ldapserver:IP-Address /subject:DN-Format
+
   Request a new certificate using the current user context but for an alternate name and SID (if supported):
 
     Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER /sid:S-1-5-21-2697957641-2271029196-387917394-2136
@@ -82,8 +86,7 @@ namespace Certify
   Request a new certificate on behalf of another user, using an enrollment agent certificate:
     
     Certify.exe request /ca:SERVER\ca-name /template:Y /onbehalfof:DOMAIN\USER /enrollcert:C:\Temp\enroll.pfx [/enrollcertpw:CERT_PASSWORD]
-
-
+    
   Download an already requested certificate:
 
     Certify.exe download /ca:SERVER\ca-name /id:X [/install] [/machine]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Certify is a C# tool to enumerate and abuse misconfigurations in Active Director
 
         Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER
 
+      Request a new certificate using the current user context but for an alternate name (if supported), specifying a ldapserver your own subject name:
+
+        Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER /ldapserver:IP-Address /subject:DN-Format
+
       Request a new certificate using the current user context but for an alternate name and SID (if supported):
 
         Certify.exe request /ca:SERVER\ca-name /template:Y /altname:USER /sid:S-1-5-21-2697957641-2271029196-387917394-2136


### PR DESCRIPTION
Had an issue recently where I was on a host that was only Entra joined and it was breaking some Certify functionality without specifying a few extra arguments that I was unable to find in the usage (had to find them through pull requests and reading the whitepaper).

By specifying the `/ldapserver` argument from #5 we were able to fix our LDAP authentications, but due to the way our subject was sent we weren't able to authenticate. 

Once we specified our username in distinguished name format rather than `/subject:DOMAIN\User` it worked perfectly. 

This pull request just adds in one line to the README/usage calling out the `/ldapserver:` argument and specifying the expected/an acceptable format of the `/subject:` argument, feel free to break them up into different commands if you think it makes more sense!