### PR TITLE
Fix uncaught exceptions in SynchronizeHttpTask

### DIFF
--- a/Certify/Util/HttpUtil.cs
+++ b/Certify/Util/HttpUtil.cs
@@ -176,9 +176,15 @@ namespace Certify.Lib
                     var response = SynchronizeHttpTask(() => client.GetAsync(url));
                     return response.StatusCode == HttpStatusCode.OK;
                 }
+                catch (AggregateException ae)
+                {
+                    var innerException = ae.InnerException ?? ae;
+                    Console.WriteLine($"[X] AuthWithChannelBinding HTTP request failed for URL '{url}' with error: {innerException.Message}");
+                    return false;
+                }
                 catch (Exception e)
                 {
-                    Console.WriteLine($"[X] AuthWithChannelBinding HTTP request failed with error: {e.Message}");
+                    Console.WriteLine($"[X] AuthWithChannelBinding HTTP request failed for URL '{url}' with error: {e.Message}");
                     return false;
                 }
             }
@@ -229,9 +235,15 @@ namespace Certify.Lib
 
                         ntlm_message = response.Headers.GetValues("WWW-Authenticate").First();
                     }
+                    catch (AggregateException ae)
+                    {
+                        var innerException = ae.InnerException ?? ae;
+                        Console.WriteLine($"[X] AuthWithoutChannelBinding HTTP request failed for URL '{url}' with error: {innerException.Message}");
+                        return false;
+                    }
                     catch (Exception e)
                     {
-                        Console.WriteLine($"[X] AuthWithoutChannelBinding HTTP request failed with error: {e.Message}");
+                        Console.WriteLine($"[X] AuthWithoutChannelBinding HTTP request failed for URL '{url}' with error: {e.Message}");
                         return false;
                     }
 
@@ -248,9 +260,15 @@ namespace Certify.Lib
                         var response = SynchronizeHttpTask(() => client.SendAsync(request_message));
                         return response.StatusCode == HttpStatusCode.OK;
                     }
+                    catch (AggregateException ae)
+                    {
+                        var innerException = ae.InnerException ?? ae;
+                        Console.WriteLine($"[X] AuthWithoutChannelBinding HTTP request failed for URL '{url}' with error: {innerException.Message}");
+                        return false;
+                    }
                     catch (Exception e)
                     {
-                        Console.WriteLine($"[X] AuthWithoutChannelBinding HTTP request failed with error: {e.Message}");
+                        Console.WriteLine($"[X] AuthWithoutChannelBinding HTTP request failed for URL '{url}' with error: {e.Message}");
                         return false;
                     }
                 }
@@ -301,9 +319,16 @@ namespace Certify.Lib
         private static HttpResponseMessage SynchronizeHttpTask(Func<Task<HttpResponseMessage>> fn)
         {
             var task = Task.Run(() => fn());
-            task.Wait();
-
-            return task.Result;
+            try
+            {
+                task.Wait();
+                return task.Result;
+            }
+            catch (AggregateException ae)
+            {
+                // Extract the inner exception from AggregateException
+                throw ae.InnerException ?? ae;
+            }
         }
     }
 }


### PR DESCRIPTION
I was encountering uncaught exceptions like the following whenever interacting with some specific CAs:

```
[!] Unhandled Certify exception:

System.AggregateException: One or more errors occurred. ---> System.Net.Http.HttpRequestException: An error occurred while sending the request. ---> System.Net.WebException: The remote server returned an error: (503) Server Unavailable.
at System.Net.HttpWebRequest.EndGetResponse(IAsyncResult asyncResult)
at System.Net.Http.HttpClientHandler.GetResponseCallback(IAsyncResult ar)
--- End of inner exception stack trace ---
--- End of inner exception stack trace ---
at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
at Certify.Lib.HttpUtil.SynchronizeHttpTask(Func`1 fn)
at Certify.Lib.HttpUtil.AuthWithChannelBinding(String url)
at Certify.Domain.CertificateAuthorityEnterprise.CheckVulnerableEsc8()
at Certify.Domain.CertificateAuthorityEnterprise.FindVulnerabilities(List`1 user_sids)
at Certify.Domain.CertificateAuthorityEnterprise..ctor(String dn, String name, String domain, Guid guid, String dns_hostname, PkiCertificateAuthorityFlags flags, List1 certificates, ActiveDirectorySecurity security_descriptor, List1 templates, List`1 user_sids)
at Certify.Lib.LdapOperations.GetEnterpriseCAs(String ca_name, List`1 user_sids)
at Certify.Commands.EnumCas.PrintEnterpriseCAs(Options opts, LdapOperations ldap, List`1 user_sids)
at Certify.Commands.EnumCas.Execute(Options opts)
at Certify.Program.ParserFinalize(ParserResult`1 result)
at Certify.Program.MainExecute(ParserResult`1 result, DefaultOptions opts)
at Certify.Program.Main(String[] args)
---> (Inner Exception #0) System.Net.Http.HttpRequestException: An error occurred while sending the request. ---> System.Net.WebException: The remote server returned an error: (503) Server Unavailable.
at System.Net.HttpWebRequest.EndGetResponse(IAsyncResult asyncResult)
at System.Net.Http.HttpClientHandler.GetResponseCallback(IAsyncResult ar)
--- End of inner exception stack trace ---<---
```

This was because when task.Wait() is called in SynchronizeHttpTask, it wraps the original exception in an AggregateException. However, the try-catch blocks in the calling methods (AuthWithChannelBinding and AuthWithoutChannelBinding) were only catching Exception, not AggregateException, so the AggregateException was propagating up and causing the unhandled exception.

I also ensured that the URL that failed is inserted into the error message.
