### PR TITLE
Check if no Templates are enabled for a CA to avoid System.ArgumentNullException

### DIFF
--- a/Certify/Commands/EnumCas.cs
+++ b/Certify/Commands/EnumCas.cs
@@ -185,7 +185,7 @@ namespace Certify.Commands
                     Console.WriteLine("    Enabled Certificate Templates:");
 
                     if (ca.Templates == null || !ca.Templates.Any())
-                        Console.WriteLine("    There are no enabled Certificate Templates");
+                        Console.WriteLine("        There are no enabled Certificate Templates");
                     else
                         Console.WriteLine("        " + string.Join("\n        ", ca.Templates));
                 }

--- a/Certify/Commands/EnumCas.cs
+++ b/Certify/Commands/EnumCas.cs
@@ -183,7 +183,11 @@ namespace Certify.Commands
                         PrintCAWebServices(ca.GetWebServices());
 
                     Console.WriteLine("    Enabled Certificate Templates:");
-                    Console.WriteLine("        " + string.Join("\n        ", ca.Templates));
+
+                    if (ca.Templates == null || !ca.Templates.Any())
+                        Console.WriteLine("    There are no enabled Certificate Templates");
+                    else
+                        Console.WriteLine("        " + string.Join("\n        ", ca.Templates));
                 }
             }
         }


### PR DESCRIPTION
I received the following error after the section `[*] Enterprise/enrollment certificate authorities:`

```
Enabled Certificate Templates:

[!] Unhandled Certify exception:

System.ArgumentNullException: Value cannot be null.
Parameter name: values
at System.String.Join(String separator, IEnumerable`1 values)
at Certify.Commands.EnumCas.PrintEnterpriseCAs(Options opts, LdapOperations ldap, List`1 user_sids) in C:\Tools\Certify-async-http-error\Certify-async-http-error\Certify\Commands\EnumCas.cs:line 186
at Certify.Commands.EnumCas.Execute(Options opts) in C:\Tools\Certify-async-http-error\Certify-async-http-error\Certify\Commands\EnumCas.cs:line 108
at Certify.Program.<>c.<ParserFinalize>b__5_0(Options opts) in C:\Tools\Certify-async-http-error\Certify-async-http-error\Certify\Program.cs:line 75
at Certify.Program.ParserFinalize(ParserResult`1 result) in C:\Tools\Certify-async-http-error\Certify-async-http-error\Certify\Program.cs:line 74
at Certify.Program.MainExecute(ParserResult`1 result, DefaultOptions opts) in C:\Tools\Certify-async-http-error\Certify-async-http-error\Certify\Program.cs:line 114
at Certify.Program.Main(String[] args) in C:\Tools\Certify-async-http-error\Certify-async-http-error\Certify\Program.cs:line 158
PS C:\Tools\Certify-async-http-error\Certify-async-http-error\Certify\bin\Debug> .\Certify.exe enum-cas
```

It turns out that it was because there was no check if `ca.Templates` is null before referencing it in a WriteLine. I added a check for if it is null or empty and a statement that there are none enabled is so. This circumvented the bug on a test.