### PR TITLE
Certificate Signing Request Generation Module Implemented

### DIFF
--- a/Certify/Certify.csproj
+++ b/Certify/Certify.csproj
@@ -100,6 +100,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\CSRGenerate.cs" />
     <Compile Include="Commands\ManageCa.cs" />
     <Compile Include="Commands\ManageSelf.cs" />
     <Compile Include="Commands\ManageTemplate.cs" />

--- a/Certify/Commands/CertRequest.cs
+++ b/Certify/Commands/CertRequest.cs
@@ -58,8 +58,6 @@ namespace Certify.Commands
             [Option("install", HelpText = "Install certificate in the current store")]
             public bool Install { get; set; }
 
-           
-
         }
 
         public static int Execute(Options opts)

--- a/Certify/Commands/CertRequest.cs
+++ b/Certify/Commands/CertRequest.cs
@@ -9,7 +9,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Linq;
 using System.DirectoryServices.AccountManagement;
-using System.IO;
 
 #if !DISARMED
 

--- a/Certify/Program.cs
+++ b/Certify/Program.cs
@@ -64,7 +64,8 @@ namespace Certify
                 CertForge.Options, 
                 ManageCa.Options, 
                 ManageTemplate.Options, 
-                ManageSelf.Options
+                ManageSelf.Options,
+                CSRGenerate.Options
 #endif
                 >(args);
         }
@@ -84,6 +85,7 @@ namespace Certify
                 (ManageCa.Options opts) => ManageCa.Execute(opts),
                 (ManageTemplate.Options opts) => ManageTemplate.Execute(opts),
                 (ManageSelf.Options opts) => ManageSelf.Execute(opts),
+                (CSRGenerate.Options opts) => CSRGenerate.Execute(opts),
 #endif
                 errors =>
                 {


### PR DESCRIPTION
A Certificate Signing Request (CSR) generation module was  implemented into the tool. This function was implemented based on the CertRequest module. 

A CSR print out to the terminal along with the Key or redirect the data into a specified file.

Note: During my previous penetration test it helped me to generate custom CSR's and bypass restrictions. I would like to share this function with the community if another testers face into restricted and hardened environments too and required to operate manual.

The generated CSR could be use for example in a Web Enrollment interface to escalate privileges.