### PR TITLE
Updated SID lookup to use ldap queries instead of LSA

### DIFF
--- a/Certify/Commands/EnumCas.cs
+++ b/Certify/Commands/EnumCas.cs
@@ -60,6 +60,9 @@ namespace Certify.Commands
 
             var ldap = new LdapOperations(opts.Domain, opts.LdapServer);
 
+            // Set LdapOps for SID resolution on non-domain joined systems
+            DisplayUtil.LdapOps = ldap;
+
             Console.WriteLine($"[*] Using the search base '{ldap.ConfigurationPath}'");
 
             List<string> user_sids = null;

--- a/Certify/Commands/EnumPkiObjects.cs
+++ b/Certify/Commands/EnumPkiObjects.cs
@@ -39,6 +39,9 @@ namespace Certify.Commands
 
             var ldap = new LdapOperations(opts.Domain, opts.LdapServer);
 
+            // Set LdapOps for SID resolution on non-domain joined systems
+            DisplayUtil.LdapOps = ldap;
+
             Console.WriteLine($"[*] Using the search base '{ldap.ConfigurationPath}'");
 
             var pki_objects = ldap.GetPKIObjects();

--- a/Certify/Commands/EnumTemplates.cs
+++ b/Certify/Commands/EnumTemplates.cs
@@ -76,6 +76,9 @@ namespace Certify.Commands
 
             var ldap = new LdapOperations(opts.Domain, opts.LdapServer);
 
+            // Set LdapOps for SID resolution on non-domain joined systems
+            DisplayUtil.LdapOps = ldap;
+
             Console.WriteLine($"[*] Using the search base '{ldap.ConfigurationPath}'");
 
             if (!string.IsNullOrEmpty(opts.CertificateAuthority))

--- a/Certify/Commands/ManageCa.cs
+++ b/Certify/Commands/ManageCa.cs
@@ -141,6 +141,10 @@ namespace Certify.Commands
                     var deleted_temps = template_pairs.RemoveAll(t => opts.ToggleTemplates.Contains(t.Item1, StringComparer.OrdinalIgnoreCase));
 
                     var ldap = new LdapOperations(opts.Domain, opts.LdapServer);
+                    
+                    // Set LdapOps for SID resolution on non-domain joined systems
+                    DisplayUtil.LdapOps = ldap;
+                    
                     var ldap_temps = ldap.GetCertificateTemplates().Where(t => t.Name != null);
 
                     var unidentified = add_templates.Where(t => !ldap_temps.Any(x => t.Equals(x.Name, StringComparison.OrdinalIgnoreCase))).ToList();

--- a/Certify/Commands/ManageTemplate.cs
+++ b/Certify/Commands/ManageTemplate.cs
@@ -90,6 +90,9 @@ namespace Certify.Commands
 
             var ldap = new LdapOperations(opts.Domain, opts.LdapServer);
 
+            // Set LdapOps for SID resolution on non-domain joined systems
+            DisplayUtil.LdapOps = ldap;
+
             Console.WriteLine($"[*] Using the search base '{ldap.ConfigurationPath}'");
 
             var template = ldap.GetCertificateTemplateEntry(opts.CertificateTemplate);

--- a/Certify/Lib/LdapOperations.cs
+++ b/Certify/Lib/LdapOperations.cs
@@ -10,6 +10,8 @@ namespace Certify.Lib
     {
         public string ConfigurationPath { get; }
         public string LdapServer { get; }
+        public string DefaultNamingContext { get; }
+        private string DomainRoot { get; }
 
         public LdapOperations()
             : this(null, null)
@@ -27,12 +29,98 @@ namespace Certify.Lib
                 root_dse_path = $"LDAP://{domain}/RootDSE";
 
             using (var root_dse = new DirectoryEntry(root_dse_path))
+            {
                 ConfigurationPath = $"{root_dse.Properties["configurationNamingContext"][0]}";
+                DefaultNamingContext = $"{root_dse.Properties["defaultNamingContext"][0]}";
+            }
 
             if (server == null)
+            {
                 LdapServer = string.Empty;
+                DomainRoot = string.Empty;
+            }
             else
+            {
                 LdapServer = $"{server}/";
+                DomainRoot = $"LDAP://{server}/";
+            }
+        }
+
+        // Resolve SID to account name using LDAP query
+        // This works on non-domain joined systems with domain credentials
+        public string GetNameFromSid(string sid)
+        {
+            if (string.IsNullOrEmpty(sid))
+                return null;
+
+            try
+            {
+                // For well-known SIDs, try local resolution first
+                if (sid.StartsWith("S-1-5-32-") || sid.StartsWith("S-1-5-18") || sid.StartsWith("S-1-1-"))
+                {
+                    try
+                    {
+                        var sid_object = new System.Security.Principal.SecurityIdentifier(sid);
+                        return sid_object.Translate(typeof(System.Security.Principal.NTAccount)).ToString();
+                    }
+                    catch
+                    {
+                        // Fall through to LDAP lookup
+                    }
+                }
+
+                // Use Global Catalog for forest-wide SID lookup
+                // GC:// searches across all domains in the forest
+                string gc_path;
+                if (string.IsNullOrEmpty(LdapServer))
+                    gc_path = "GC://";
+                else
+                    gc_path = $"GC://{LdapServer.TrimEnd('/')}";
+
+                using (var searcher = new DirectorySearcher(new DirectoryEntry(gc_path)))
+                {
+                    searcher.Filter = $"(objectSid={ConvertSidToLdapFilter(sid)})";
+                    searcher.PropertiesToLoad.Add("sAMAccountName");
+                    searcher.PropertiesToLoad.Add("name");
+                    searcher.SearchScope = SearchScope.Subtree;
+
+                    var result = searcher.FindOne();
+                    if (result != null)
+                    {
+                        if (result.Properties.Contains("sAMAccountName"))
+                            return result.Properties["sAMAccountName"][0].ToString();
+                        else if (result.Properties.Contains("name"))
+                            return result.Properties["name"][0].ToString();
+                    }
+                }
+            }
+            catch
+            {
+                // Silently fail and return null
+            }
+
+            return null;
+        }
+
+        // Convert SID string to LDAP filter format
+        private string ConvertSidToLdapFilter(string sid)
+        {
+            try
+            {
+                var sid_object = new System.Security.Principal.SecurityIdentifier(sid);
+                var sid_bytes = new byte[sid_object.BinaryLength];
+                sid_object.GetBinaryForm(sid_bytes, 0);
+
+                var hex_string = "";
+                foreach (byte b in sid_bytes)
+                    hex_string += $"\\{b:x2}";
+
+                return hex_string;
+            }
+            catch
+            {
+                return sid;
+            }
         }
 
         public IEnumerable<PKIObject> GetPKIObjects()

--- a/Certify/Lib/LdapOperations.cs
+++ b/Certify/Lib/LdapOperations.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.DirectoryServices;
 using System.Linq;
@@ -82,15 +82,32 @@ namespace Certify.Lib
                     searcher.Filter = $"(objectSid={ConvertSidToLdapFilter(sid)})";
                     searcher.PropertiesToLoad.Add("sAMAccountName");
                     searcher.PropertiesToLoad.Add("name");
+                    searcher.PropertiesToLoad.Add("distinguishedName");
                     searcher.SearchScope = SearchScope.Subtree;
 
                     var result = searcher.FindOne();
                     if (result != null)
                     {
+                        string accountName = null;
+                        
                         if (result.Properties.Contains("sAMAccountName"))
-                            return result.Properties["sAMAccountName"][0].ToString();
+                            accountName = result.Properties["sAMAccountName"][0].ToString();
                         else if (result.Properties.Contains("name"))
-                            return result.Properties["name"][0].ToString();
+                            accountName = result.Properties["name"][0].ToString();
+                        
+                        if (!string.IsNullOrEmpty(accountName))
+                        {
+                            // Extract domain from DN (DC=domain,DC=com -> DOMAIN)
+                            if (result.Properties.Contains("distinguishedName"))
+                            {
+                                var dn = result.Properties["distinguishedName"][0].ToString();
+                                var domain = ExtractDomainFromDN(dn);
+                                if (!string.IsNullOrEmpty(domain))
+                                    return $"{domain}\\{accountName}";
+                            }
+                            
+                            return accountName;
+                        }
                     }
                 }
             }
@@ -100,6 +117,41 @@ namespace Certify.Lib
             }
 
             return null;
+        }
+
+        // Extract NetBIOS domain name from Distinguished Name
+        // DC=contoso,DC=com -> CONTOSO
+        private string ExtractDomainFromDN(string dn)
+        {
+            if (string.IsNullOrEmpty(dn))
+                return null;
+
+            try
+            {
+                // Find the first DC= component
+                var dcIndex = dn.IndexOf("DC=", StringComparison.OrdinalIgnoreCase);
+                if (dcIndex == -1)
+                    return null;
+
+                // Extract all DC components
+                var dcPart = dn.Substring(dcIndex);
+                var dcComponents = new List<string>();
+
+                foreach (var part in dcPart.Split(','))
+                {
+                    var trimmed = part.Trim();
+                    if (trimmed.StartsWith("DC=", StringComparison.OrdinalIgnoreCase))
+                        dcComponents.Add(trimmed.Substring(3));
+                }
+
+                // Return the first component (NetBIOS-style domain name)
+                // For full FQDN, you could return string.Join(".", dcComponents)
+                return dcComponents.Count > 0 ? dcComponents[0].ToUpper() : null;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         // Convert SID string to LDAP filter format

--- a/Certify/Util/DisplayUtil.cs
+++ b/Certify/Util/DisplayUtil.cs
@@ -13,6 +13,10 @@ namespace Certify.Lib
 {
     class DisplayUtil
     {
+        // LdapOperations instance for SID resolution
+        // Set this before calling Display methods for proper SID resolution on non-domain joined systems
+        public static LdapOperations LdapOps { get; set; }
+
         public static void PrintPkiObjectControllers(Dictionary<string, List<Tuple<string, string>>> object_controllers, bool hide_admins)
         {
             foreach (var object_controller in object_controllers.OrderBy(o => GetUserNameFromSid(o.Key)))
@@ -368,6 +372,22 @@ namespace Certify.Lib
 
         public static string GetUserNameFromSid(string sid)
         {
+            // Try LDAP-based resolution first (works on non-domain joined systems)
+            if (LdapOps != null)
+            {
+                try
+                {
+                    var name = LdapOps.GetNameFromSid(sid);
+                    if (!string.IsNullOrEmpty(name))
+                        return name;
+                }
+                catch
+                {
+                    // Fall through to Translate() method
+                }
+            }
+
+            // Fallback to local resolution (may fail on non-domain joined systems)
             try
             {
                 var sid_object = new SecurityIdentifier(sid);


### PR DESCRIPTION
In almost every engagement the tool is run off a host that is NOT domain joined via runas. 
However, the SID resolution failed:
<img width="1102" height="258" alt="image" src="https://github.com/user-attachments/assets/086ee8cd-8492-43dd-929b-620e8b21e1b4" />
<img width="1010" height="581" alt="image" src="https://github.com/user-attachments/assets/621ad483-b33c-456a-a7a5-7d612090a064" />

The code uses ``SecurityIdentifier.Translate(typeof(NTAccount))`` which relies on the local LSA for resolving SIDs. On non-domain joined systems, this fails even with domain credentials via runas.
Hence LDAP based resolution was implemented to overcome these limitations.

<img width="1111" height="259" alt="image" src="https://github.com/user-attachments/assets/d5d8bdb9-5ca6-4051-af74-b5aa89c84752" />

<img width="1015" height="575" alt="image" src="https://github.com/user-attachments/assets/02686b50-a872-420a-aae8-ba5d80532c36" />
