### PR TITLE
Add LDAP authentication support to LdapOperations

### DIFF
--- a/Certify/Commands/CertRequest.cs
+++ b/Certify/Commands/CertRequest.cs
@@ -1,8 +1,9 @@
-﻿using CERTENROLLLib;
+using CERTENROLLLib;
 using Certify.Lib;
 using CommandLine;
 using System;
 using System.Collections.Generic;
+using System.Security;
 using System.Security.Principal;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -60,6 +61,12 @@ namespace Certify.Commands
 
             [Option("install", HelpText = "Install certificate in the current store")]
             public bool Install { get; set; }
+
+            [Option('u', "username", HelpText = "Username for authentication (format: user@domain.fqdn). Omit to use the current user.")]
+            public string Username { get; set; }
+
+            [Option('p', "password", HelpText = "Password for authentication. If omitted while --username is set, you'll be prompted (input hidden).")]
+            public string Password { get; set; }
         }
 
         public static int Execute(Options opts)
@@ -85,6 +92,12 @@ namespace Certify.Commands
             {
                 Console.WriteLine("[X] The 'key size' parameter must be either 512, 1024, 2048 or 4096.");
                 return 1;
+            }
+
+            // Prompt for password if a username was given but no password was provided
+            if (!string.IsNullOrEmpty(opts.Username) && string.IsNullOrEmpty(opts.Password))
+            {
+                opts.Password = ReadPasswordMasked($"Password for {opts.Username}: ");
             }
 
             var sans = new List<Tuple<SubjectAltNameType, string>>();
@@ -118,6 +131,9 @@ namespace Certify.Commands
                 Console.WriteLine();
                 Console.WriteLine($"[*] Current user context    : {WindowsIdentity.GetCurrent().Name}");
 
+                if (!string.IsNullOrEmpty(opts.Username))
+                    Console.WriteLine($"[*] Authenticating as        : {opts.Username}");
+
                 var subject_name = opts.SubjectName;
 
                 if (string.IsNullOrEmpty(subject_name))
@@ -136,7 +152,7 @@ namespace Certify.Commands
                         Console.WriteLine($"[*] No subject name specified, using current context as subject.");
                     }
                 }
-                
+
                 if (string.IsNullOrEmpty(subject_name))
                 {
                     subject_name = "CN=User";
@@ -156,7 +172,7 @@ namespace Certify.Commands
                 if (opts.ApplicationPolicies != null && opts.ApplicationPolicies.Any())
                     Console.WriteLine($"[*] Application Policies    : {string.Join(", ", opts.ApplicationPolicies)}");
 
-                var csr = CertEnrollment.CreateCertRequestMessage(opts.TemplateName, subject_name, sans, 
+                var csr = CertEnrollment.CreateCertRequestMessage(opts.TemplateName, subject_name, sans,
                     opts.SidExtension, opts.ApplicationPolicies, opts.KeySize, opts.MachineContext);
 
                 Console.WriteLine();
@@ -173,10 +189,10 @@ namespace Certify.Commands
                     Console.WriteLine(csr.Item2);
                 }
                 else
-                { 
+                {
                     try
                     {
-                        int request_id = CertEnrollment.SendCertificateRequest(opts.CertificateAuthority, csr.Item1);
+                        int request_id = CertEnrollment.SendCertificateRequest(opts.CertificateAuthority, csr.Item1, opts.Username, opts.Password);
 
                         Console.WriteLine($"[*] Request ID              : {request_id}");
                         Console.WriteLine();
@@ -186,9 +202,9 @@ namespace Certify.Commands
                         var certificate_pem = string.Empty;
 
                         if (!opts.Install)
-                            certificate_pem = CertEnrollment.DownloadCert(opts.CertificateAuthority, request_id);
+                            certificate_pem = CertEnrollment.DownloadCert(opts.CertificateAuthority, request_id, opts.Username, opts.Password);
                         else
-                            certificate_pem = CertEnrollment.DownloadAndInstallCert(opts.CertificateAuthority, request_id, X509CertificateEnrollmentContext.ContextUser);
+                            certificate_pem = CertEnrollment.DownloadAndInstallCert(opts.CertificateAuthority, request_id, X509CertificateEnrollmentContext.ContextUser, opts.Username, opts.Password);
 
                         if (opts.OutputPem)
                         {
@@ -228,6 +244,47 @@ namespace Certify.Commands
         private static string GetCurrentComputerDN()
         {
             return $"CN={System.Net.Dns.GetHostEntry("").HostName}";
+        }
+
+        // Reads a password from the console without echoing it to the screen.
+        private static string ReadPasswordMasked(string prompt)
+        {
+            Console.Write(prompt);
+
+            var secure = new SecureString();
+
+            ConsoleKeyInfo key;
+            while ((key = Console.ReadKey(intercept: true)).Key != ConsoleKey.Enter)
+            {
+                if (key.Key == ConsoleKey.Backspace)
+                {
+                    if (secure.Length > 0)
+                    {
+                        secure.RemoveAt(secure.Length - 1);
+                        Console.Write("\b \b");
+                    }
+                    continue;
+                }
+
+                if (key.KeyChar != '\0')
+                {
+                    secure.AppendChar(key.KeyChar);
+                    Console.Write('*');
+                }
+            }
+
+            Console.WriteLine();
+            secure.MakeReadOnly();
+
+            var ptr = System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(secure);
+            try
+            {
+                return System.Runtime.InteropServices.Marshal.PtrToStringUni(ptr);
+            }
+            finally
+            {
+                System.Runtime.InteropServices.Marshal.ZeroFreeGlobalAllocUnicode(ptr);
+            }
         }
     }
 }

--- a/Certify/Commands/EnumCas.cs
+++ b/Certify/Commands/EnumCas.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.DirectoryServices.AccountManagement;
 using System.Linq;
+using System.Security;
 using System.Security.Principal;
 
 namespace Certify.Commands
@@ -63,6 +64,11 @@ namespace Certify.Commands
             {
                 Console.WriteLine("[X] The 'domain' parameter is not a fully qualified domain name.");
                 return 1;
+            }
+
+            if (!string.IsNullOrEmpty(opts.Username) && string.IsNullOrEmpty(opts.Password))
+            {
+                opts.Password = ReadPasswordMasked($"Password for {opts.Username}: ");
             }
 
             var ldap = new LdapOperations(opts.Domain, opts.LdapServer, opts.Username, opts.Password);
@@ -196,6 +202,46 @@ namespace Certify.Commands
                     else
                         Console.WriteLine("        " + string.Join("\n        ", ca.Templates));
                 }
+            }
+        }
+
+        private static string ReadPasswordMasked(string prompt)
+        {
+            Console.Write(prompt);
+
+            var secure = new SecureString();
+
+            ConsoleKeyInfo key;
+            while ((key = Console.ReadKey(intercept: true)).Key != ConsoleKey.Enter)
+            {
+                if (key.Key == ConsoleKey.Backspace)
+                {
+                    if (secure.Length > 0)
+                    {
+                        secure.RemoveAt(secure.Length - 1);
+                        Console.Write("\b \b");
+                    }
+                    continue;
+                }
+
+                if (key.KeyChar != '\0')
+                {
+                    secure.AppendChar(key.KeyChar);
+                    Console.Write('*');
+                }
+            }
+
+            Console.WriteLine();
+            secure.MakeReadOnly();
+
+            var ptr = System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(secure);
+            try
+            {
+                return System.Runtime.InteropServices.Marshal.PtrToStringUni(ptr);
+            }
+            finally
+            {
+                System.Runtime.InteropServices.Marshal.ZeroFreeGlobalAllocUnicode(ptr);
             }
         }
 

--- a/Certify/Commands/EnumCas.cs
+++ b/Certify/Commands/EnumCas.cs
@@ -1,4 +1,4 @@
-﻿using Certify.Domain;
+using Certify.Domain;
 using Certify.Lib;
 using CommandLine;
 using System;
@@ -40,6 +40,13 @@ namespace Certify.Commands
 
             [Option("skip-web-checks", HelpText = "Skip web service checks")]
             public bool SkipWebServiceChecks { get; set; }
+            
+            [Option('u', "username", HelpText = "Username for LDAP bind (format: user@domain.fqdn). Omit to bind as the current user.")]
+            public string Username { get; set; }
+
+            [Option('p', "password", HelpText = "Password for LDAP bind. If omitted while --username is set, you'll be prompted (input hidden).")]
+            public string Password { get; set; }
+            
         }
 
         public static int Execute(Options opts)
@@ -58,7 +65,7 @@ namespace Certify.Commands
                 return 1;
             }
 
-            var ldap = new LdapOperations(opts.Domain, opts.LdapServer);
+            var ldap = new LdapOperations(opts.Domain, opts.LdapServer, opts.Username, opts.Password);
 
             Console.WriteLine($"[*] Using the search base '{ldap.ConfigurationPath}'");
 

--- a/Certify/Commands/EnumPkiObjects.cs
+++ b/Certify/Commands/EnumPkiObjects.cs
@@ -1,4 +1,4 @@
-﻿using Certify.Domain;
+using Certify.Domain;
 using Certify.Lib;
 using CommandLine;
 using System;
@@ -25,6 +25,12 @@ namespace Certify.Commands
 
             [Option("show-admins", HelpText = "Include admin permissions")]
             public bool ShowAdmins { get; set; }
+            
+            [Option('u', "username", HelpText = "Username for LDAP bind (format: user@domain.fqdn). Omit to bind as the current user.")]
+            public string Username { get; set; }
+
+            [Option('p', "password", HelpText = "Password for LDAP bind. If omitted while --username is set, you'll be prompted (input hidden).")]
+            public string Password { get; set; }
         }
 
         public static int Execute(Options opts)
@@ -37,7 +43,7 @@ namespace Certify.Commands
                 return 1;
             }
 
-            var ldap = new LdapOperations(opts.Domain, opts.LdapServer);
+            var ldap = new LdapOperations(opts.Domain, opts.LdapServer, opts.Username, opts.Password);
 
             Console.WriteLine($"[*] Using the search base '{ldap.ConfigurationPath}'");
 

--- a/Certify/Commands/EnumPkiObjects.cs
+++ b/Certify/Commands/EnumPkiObjects.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.DirectoryServices;
 using System.Linq;
+using System.Security;
 using System.Security.Principal;
 
 namespace Certify.Commands
@@ -43,6 +44,11 @@ namespace Certify.Commands
                 return 1;
             }
 
+            if (!string.IsNullOrEmpty(opts.Username) && string.IsNullOrEmpty(opts.Password))
+            {
+                opts.Password = ReadPasswordMasked($"Password for {opts.Username}: ");
+            }
+
             var ldap = new LdapOperations(opts.Domain, opts.LdapServer, opts.Username, opts.Password);
 
             Console.WriteLine($"[*] Using the search base '{ldap.ConfigurationPath}'");
@@ -78,6 +84,46 @@ namespace Certify.Commands
             return 0;
         }
         
+        private static string ReadPasswordMasked(string prompt)
+        {
+            Console.Write(prompt);
+
+            var secure = new SecureString();
+
+            ConsoleKeyInfo key;
+            while ((key = Console.ReadKey(intercept: true)).Key != ConsoleKey.Enter)
+            {
+                if (key.Key == ConsoleKey.Backspace)
+                {
+                    if (secure.Length > 0)
+                    {
+                        secure.RemoveAt(secure.Length - 1);
+                        Console.Write("\b \b");
+                    }
+                    continue;
+                }
+
+                if (key.KeyChar != '\0')
+                {
+                    secure.AppendChar(key.KeyChar);
+                    Console.Write('*');
+                }
+            }
+
+            Console.WriteLine();
+            secure.MakeReadOnly();
+
+            var ptr = System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(secure);
+            try
+            {
+                return System.Runtime.InteropServices.Marshal.PtrToStringUni(ptr);
+            }
+            finally
+            {
+                System.Runtime.InteropServices.Marshal.ZeroFreeGlobalAllocUnicode(ptr);
+            }
+        }
+
         private static Dictionary<string, List<Tuple<string, string>>> GetPkiObjectControllers(IEnumerable<PKIObject> pki_objects)
         {
             var object_controllers = new Dictionary<string, List<Tuple<string, string>>>();

--- a/Certify/Commands/EnumTemplates.cs
+++ b/Certify/Commands/EnumTemplates.cs
@@ -1,4 +1,4 @@
-﻿using Certify.Domain;
+using Certify.Domain;
 using Certify.Lib;
 using CommandLine;
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.DirectoryServices.AccountManagement;
 using System.Linq;
+using System.Security;
 using System.Security.Principal;
 
 namespace Certify.Commands
@@ -56,6 +57,12 @@ namespace Certify.Commands
 
             [Option("show-all-perms", HelpText = "Show all permission details")]
             public bool ShowAllPermissions { get; set; }
+            
+            [Option('u', "username", HelpText = "Username for LDAP bind (format: user@domain.fqdn). Omit to bind as the current user.")]
+            public string Username { get; set; }
+
+            [Option('p', "password", HelpText = "Password for LDAP bind. If omitted while --username is set, you'll be prompted (input hidden).")]
+            public string Password { get; set; }
         }
 
         public static int Execute(Options opts)
@@ -74,7 +81,15 @@ namespace Certify.Commands
                 return 1;
             }
 
-            var ldap = new LdapOperations(opts.Domain, opts.LdapServer);
+            // If a username was given but no password, prompt interactively instead of
+            // requiring the password on the command line (avoids it sitting in shell
+            // history / process listings).
+            if (!string.IsNullOrEmpty(opts.Username) && string.IsNullOrEmpty(opts.Password))
+            {
+                opts.Password = ReadPasswordMasked($"Password for {opts.Username}: ");
+            }
+
+            var ldap = new LdapOperations(opts.Domain, opts.LdapServer, opts.Username, opts.Password);
 
             Console.WriteLine($"[*] Using the search base '{ldap.ConfigurationPath}'");
 
@@ -246,6 +261,49 @@ namespace Certify.Commands
             }
 
             return 0;
+        }
+
+        // Reads a password from the console without echoing it back to the screen.
+        // Keeps the value in a SecureString while typing, then converts to a plain
+        // string only at the point LdapOperations needs it.
+        private static string ReadPasswordMasked(string prompt)
+        {
+            Console.Write(prompt);
+
+            var secure = new SecureString();
+
+            ConsoleKeyInfo key;
+            while ((key = Console.ReadKey(intercept: true)).Key != ConsoleKey.Enter)
+            {
+                if (key.Key == ConsoleKey.Backspace)
+                {
+                    if (secure.Length > 0)
+                    {
+                        secure.RemoveAt(secure.Length - 1);
+                        Console.Write("\b \b");
+                    }
+                    continue;
+                }
+
+                if (key.KeyChar != '\0')
+                {
+                    secure.AppendChar(key.KeyChar);
+                    Console.Write('*');
+                }
+            }
+
+            Console.WriteLine();
+            secure.MakeReadOnly();
+
+            var ptr = System.Runtime.InteropServices.Marshal.SecureStringToGlobalAllocUnicode(secure);
+            try
+            {
+                return System.Runtime.InteropServices.Marshal.PtrToStringUni(ptr);
+            }
+            finally
+            {
+                System.Runtime.InteropServices.Marshal.ZeroFreeGlobalAllocUnicode(ptr);
+            }
         }
     }
 }

--- a/Certify/Lib/ImpersonationHelper.cs
+++ b/Certify/Lib/ImpersonationHelper.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+
+#if !DISARMED
+
+namespace Certify.Lib
+{
+    // Allows running a block of code impersonated as a different Windows user.
+    // Usage:
+    //   using (ImpersonationHelper.Impersonate(username, domain, password))
+    //   {
+    //       // code runs as the supplied user
+    //   }
+    //   // back to original identity here
+    internal class ImpersonationHelper : IDisposable
+    {
+        private readonly WindowsImpersonationContext _context;
+        private readonly SafeTokenHandle _token;
+
+        private const int LOGON32_LOGON_NEW_CREDENTIALS = 9; // best for network access to remote resources
+        private const int LOGON32_PROVIDER_WINNT50 = 3;
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern bool LogonUser(
+            string lpszUsername,
+            string lpszDomain,
+            string lpszPassword,
+            int dwLogonType,
+            int dwLogonProvider,
+            out SafeTokenHandle phToken);
+
+        private ImpersonationHelper(WindowsImpersonationContext context, SafeTokenHandle token)
+        {
+            _context = context;
+            _token = token;
+        }
+
+        // Returns null if username is empty — callers can use it in a null-safe using block
+        public static ImpersonationHelper Impersonate(string username, string password)
+        {
+            if (string.IsNullOrEmpty(username))
+                return null;
+
+            // Split domain\user or user@domain into parts LogonUser expects
+            string domain = ".";
+            string user = username;
+
+            if (username.Contains("\\"))
+            {
+                var parts = username.Split(new[] { '\\' }, 2);
+                domain = parts[0];
+                user = parts[1];
+            }
+            else if (username.Contains("@"))
+            {
+                // UPN format — pass as-is with empty domain
+                domain = string.Empty;
+                user = username;
+            }
+
+            if (!LogonUser(user, domain, password, LOGON32_LOGON_NEW_CREDENTIALS, LOGON32_PROVIDER_WINNT50, out var token))
+                throw new System.ComponentModel.Win32Exception(Marshal.GetLastWin32Error(),
+                    $"LogonUser failed for '{username}'. Check credentials.");
+
+            var identity = new WindowsIdentity(token.DangerousGetHandle());
+            var context = identity.Impersonate();
+
+            return new ImpersonationHelper(context, token);
+        }
+
+        public void Dispose()
+        {
+            _context?.Undo();
+            _context?.Dispose();
+            _token?.Dispose();
+        }
+    }
+
+    // Safe wrapper around a Win32 token handle
+    internal class SafeTokenHandle : SafeHandle
+    {
+        private SafeTokenHandle() : base(IntPtr.Zero, true) { }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        [DllImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CloseHandle(IntPtr hObject);
+
+        protected override bool ReleaseHandle()
+        {
+            return CloseHandle(handle);
+        }
+    }
+}
+
+#endif

--- a/Certify/Lib/LdapOperations.cs
+++ b/Certify/Lib/LdapOperations.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.DirectoryServices;
 using System.Linq;
@@ -11,14 +11,23 @@ namespace Certify.Lib
         public string ConfigurationPath { get; }
         public string LdapServer { get; }
 
+        // Stored once, reused by every method below instead of literal strings.
+        private readonly string _username;
+        private readonly string _password;
+        private readonly AuthenticationTypes _authType;
+
         public LdapOperations()
             : this(null, null)
         {
 
         }
 
-        public LdapOperations(string domain, string server)
+        public LdapOperations(string domain, string server, string username = null, string password = null)
         {
+            _username = username;
+            _password = password;
+            _authType = AuthenticationTypes.Secure;
+
             string root_dse_path;
 
             if (domain == null)
@@ -27,12 +36,34 @@ namespace Certify.Lib
                 root_dse_path = $"LDAP://{domain}/RootDSE";
 
             using (var root_dse = new DirectoryEntry(root_dse_path))
+            {
+                root_dse.Username = _username;
+                root_dse.Password = _password;
+                root_dse.AuthenticationType = _authType;
                 ConfigurationPath = $"{root_dse.Properties["configurationNamingContext"][0]}";
+            }
+
 
             if (server == null)
                 LdapServer = string.Empty;
             else
                 LdapServer = $"{server}/";
+        }
+
+        // Single place that builds an authenticated DirectoryEntry.
+        // Every method now calls this instead of repeating Username/Password/AuthenticationType assignments.
+        private DirectoryEntry GetDirectoryEntry(string path)
+        {
+            var entry = new DirectoryEntry(path);
+
+            if (!string.IsNullOrEmpty(_username))
+            {
+                entry.Username = _username;
+                entry.Password = _password;
+                entry.AuthenticationType = _authType;
+            }
+
+            return entry;
         }
 
         public IEnumerable<PKIObject> GetPKIObjects()
@@ -42,7 +73,7 @@ namespace Certify.Lib
             // Container location per MS-WCCE 2.2.2.11.2 Enrollment Services Container
             // - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/3ec073ec-9b91-4bee-964e-56f22a93a28c
 
-            using (var root = new DirectoryEntry($"LDAP://{LdapServer}CN=Public Key Services,CN=Services,{ConfigurationPath}"))
+            using (var root = GetDirectoryEntry($"LDAP://{LdapServer}CN=Public Key Services,CN=Services,{ConfigurationPath}"))
             {
                 using (var ds = new DirectorySearcher(root) { SecurityMasks = SecurityMasks.Dacl | SecurityMasks.Owner })
                 {
@@ -98,7 +129,7 @@ namespace Certify.Lib
             // Container location per MS-WCCE 2.2.2.11.2 Enrollment Services Container
             // - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/3ec073ec-9b91-4bee-964e-56f22a93a28c
 
-            using (var root = new DirectoryEntry($"LDAP://{LdapServer}CN=Enrollment Services,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
+            using (var root = GetDirectoryEntry($"LDAP://{LdapServer}CN=Enrollment Services,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
             {
                 using (var ds = new DirectorySearcher(root) { SecurityMasks = SecurityMasks.Dacl | SecurityMasks.Owner })
                 {
@@ -136,7 +167,7 @@ namespace Certify.Lib
             // Container location per MS-WCCE 2.2.2.11.3 NTAuthCertificates Object
             // - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/f1004c63-8508-43b5-9b0b-ee7880183745
 
-            using (var root = new DirectoryEntry($"LDAP://{LdapServer}CN=NTAuthCertificates,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
+            using (var root = GetDirectoryEntry($"LDAP://{LdapServer}CN=NTAuthCertificates,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
             {
                 using (var ds = new DirectorySearcher(root) { Filter = "(objectClass=certificationAuthority)" })
                 {
@@ -168,7 +199,7 @@ namespace Certify.Lib
             // Container location per MS-WCCE 2.2.2.11.1 Certificates Templates Container
             // - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/9279abb2-3dfa-4631-845c-43c187ac4b44
 
-            using (var root = new DirectoryEntry($"LDAP://{LdapServer}CN=Certificate Templates,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
+            using (var root = GetDirectoryEntry($"LDAP://{LdapServer}CN=Certificate Templates,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
             {
                 using (var ds = new DirectorySearcher(root) { SecurityMasks = SecurityMasks.Dacl | SecurityMasks.Owner, Filter = "(objectclass=pKICertificateTemplate)" })
                 {
@@ -207,7 +238,7 @@ namespace Certify.Lib
 
         public DirectoryEntry GetCertificateTemplateEntry(string template)
         {
-            using (var root = new DirectoryEntry($"LDAP://{LdapServer}CN=Certificate Templates,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
+            using (var root = GetDirectoryEntry($"LDAP://{LdapServer}CN=Certificate Templates,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
             {
                 using (var ds = new DirectorySearcher(root) { SecurityMasks = SecurityMasks.Dacl | SecurityMasks.Owner, Filter = $"(&(objectclass=pKICertificateTemplate)(name={template}))" })
                 {
@@ -231,7 +262,7 @@ namespace Certify.Lib
             // Container location per MS-WCCE 2.2.2.11.4 Certification Authorities Container
             // - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/6c446198-f670-4885-97a9-cbc50a2b96b4
 
-            using (var root = new DirectoryEntry($"LDAP://{LdapServer}CN=Certification Authorities,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
+            using (var root = GetDirectoryEntry($"LDAP://{LdapServer}CN=Certification Authorities,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
             {
                 using (var ds = new DirectorySearcher(root) { Filter = "(objectCategory=certificationAuthority)" })
                 {
@@ -260,7 +291,7 @@ namespace Certify.Lib
         {
             var oids = new List<CertificateEnterpriseOid>();
 
-            using (var root = new DirectoryEntry($"LDAP://{LdapServer}CN=OID,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
+            using (var root = GetDirectoryEntry($"LDAP://{LdapServer}CN=OID,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
             {
                 using (var ds = new DirectorySearcher(root) { Filter = "(objectClass=msPKI-Enterprise-Oid)" })
                 {
@@ -286,7 +317,7 @@ namespace Certify.Lib
 
         public CertificateEnterpriseOid GetEnterpriseOid(string oid)
         {
-            using (var root = new DirectoryEntry($"LDAP://{LdapServer}CN=OID,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
+            using (var root = GetDirectoryEntry($"LDAP://{LdapServer}CN=OID,CN=Public Key Services,CN=Services,{ConfigurationPath}"))
             {
                 using (var ds = new DirectorySearcher(root) { Filter = $"(msPKI-Cert-Template-OID={oid})" })
                 {


### PR DESCRIPTION
Description
Right now LdapOperations can only talk to LDAP as whoever is currently logged in — there's no way to pass in a different username/password. This PR adds that.
What changed:

Added a small private helper, GetDirectoryEntry(), that builds the DirectoryEntry and applies the username/password if they were given.
Swapped all the methods (GetPKIObjects, GetEnterpriseCAs, GetCertificateTemplates, etc.) to use this helper instead of creating DirectoryEntry objects on their own.

Why:

Sometimes you need to run this as a specific account instead of the current user (e.g. from a non-domain-joined box, or with a service account). There was no clean way to do that before.
Does this break anything?

Nope — if you don't pass a username/password, it works exactly like before (current user auth). If you do pass them, they're now actually used everywhere instead of just in the constructor.
Tested:

Ran it with --username/--password and confirmed the bind works.
Ran it with no credentials and confirmed it still works as current user.